### PR TITLE
changes to build for node-v10

### DIFF
--- a/src/heap_graph_node.cc
+++ b/src/heap_graph_node.cc
@@ -66,7 +66,15 @@ namespace nodex {
     Local<Object> graph_node;
     Local<Object> _cache = Nan::New(graph_node_cache);
     int32_t _id = node->GetId();
-    if (_cache->Has(_id)) {
+// TODO: find which v8 version changed the api
+#if (NODE_MAJOR_VERSION <= 8)
+    int cacheHasId = _cache->Has(_id);
+#else
+    // TODO: find a way to alloc the object on the stack
+     Local<Value> _idValue = Nan::New(_id);
+    int cacheHasId = _cache->Has(_idValue);
+#endif
+    if (cacheHasId) {
       graph_node = _cache->Get(_id)->ToObject();
     } else {
       graph_node = Nan::New(graph_node_template_)->NewInstance();

--- a/src/heap_output_stream.cc
+++ b/src/heap_output_stream.cc
@@ -1,3 +1,4 @@
+#include "nan.h"
 #include "heap_output_stream.h"
 
 namespace nodex {
@@ -9,7 +10,7 @@ namespace nodex {
   using v8::String;
   using v8::OutputStream;
   using v8::Function;
-  using v8::TryCatch;;
+  using Nan::TryCatch;;
   using v8::Integer;
 
   void OutputStreamAdapter::EndOfStream() {

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -1,3 +1,4 @@
+#include "nan.h"
 #include "heap_profiler.h"
 #include "heap_snapshot.h"
 #include "heap_output_stream.h"
@@ -13,7 +14,7 @@ namespace nodex {
   using v8::Object;
   using v8::SnapshotObjectId;
   using v8::String;
-  using v8::TryCatch;
+  using Nan::TryCatch;
   using v8::Value;
 
   HeapProfiler::HeapProfiler() {}

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -74,6 +74,7 @@ namespace nodex {
 #endif
 
 #if (NODE_MODULE_VERSION > 0x0038)
+    control = control; // silence the "unused variable" warning
     const HeapSnapshot* snapshot = v8::Isolate::GetCurrent()->GetHeapProfiler()->TakeHeapSnapshot();
 #elif (NODE_MODULE_VERSION > 0x002C)
     const HeapSnapshot* snapshot = v8::Isolate::GetCurrent()->GetHeapProfiler()->TakeHeapSnapshot(control);


### PR DESCRIPTION
- `TryCatch` changed, use the portable version from `nan`
- `_cache->Has()` api changed, now takes a Value object
- fix a minor unused variable warning

This is a quick change to get it to build with node-v10.12, perhaps not ideal but makes it work.
The unit tests pass.